### PR TITLE
allow case-sensitive URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# uniloc-case-sensitive
+
+This is a fork of [uniloc](https://github.com/unicorn-standard/uniloc) to use case-sensitive URLs.
+
+
 # uniloc
 
 Uniloc is a utility to match URIs to named routes, and to generate URIs given a route name and options.

--- a/package.json
+++ b/package.json
@@ -1,22 +1,27 @@
 {
-  "name": "uniloc",
+  "name": "uniloc-case-sensitive",
   "version": "0.2.0",
-  "description": "Universal JavaScript Route Parsing and Generation in 1.3KB compressed/minified",
+  "description": "Forked version of Universal JavaScript Route Parsing and Generation in 1.3KB compressed/minified",
+  "author": "James K Nelson <james@jamesknelson.com>",
+  "contributors": [{
+    "name": "Harald Tobler",
+    "email": "harald.tobler@seriouscircus.com"
+  }],
   "main": "uniloc.js",
   "scripts": {
     "test": "npm run test"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unicorn-standard/uniloc.git"
+    "url": "git+https://github.com/seriouscircus/uniloc.git"
   },
   "keywords": [
     "uniloc",
     "routing",
     "unicorn-standard",
-    "tiny"
+    "tiny",
+    "case-sensitive"
   ],
-  "author": "James K Nelson <james@jamesknelson.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/unicorn-standard/uniloc/issues"

--- a/uniloc.js
+++ b/uniloc.js
@@ -11,7 +11,7 @@
   }
 
   function pathParts(path) {
-    return path == '' ? [] : path.toLowerCase().split('/')
+    return path == '' ? [] : path.split('/')
   }
 
   function routeParts(route) {


### PR DESCRIPTION
We want to store case-sensitive object IDs in the path.
What is the reason to force URLs to lowercase?
